### PR TITLE
feat(auth): update signup and OTP flow with new API endpoints and use…

### DIFF
--- a/fix_connect_mobile/lib/app/router/app_router.dart
+++ b/fix_connect_mobile/lib/app/router/app_router.dart
@@ -17,6 +17,8 @@ import 'package:fix_connect_mobile/features/home/presentation/pages/service_deta
 import 'package:fix_connect_mobile/features/home/presentation/pages/services_all_page.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/data/models/otp_args.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/presentation/blocs/login_bloc.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/presentation/blocs/otp_bloc.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/presentation/blocs/signup_bloc.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/presentation/pages/forgot_password_page.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/presentation/pages/login_page.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/presentation/pages/otp_page.dart';
@@ -72,10 +74,20 @@ class RouteGenerator {
           ),
         );
       case AppRoutes.signup:
-        return MaterialPageRoute(builder: (_) => const SignupPage());
+        return MaterialPageRoute(
+          builder: (_) => BlocProvider(
+            create: (_) => sl<SignupBloc>(),
+            child: const SignupPage(),
+          ),
+        );
       case AppRoutes.otp:
         final args = settings.arguments as OtpArgs;
-        return MaterialPageRoute(builder: (_) => OtpPage(args: args));
+        return MaterialPageRoute(
+          builder: (_) => BlocProvider(
+            create: (_) => sl<OtpBloc>(),
+            child: OtpPage(args: args),
+          ),
+        );
       case AppRoutes.forgotPassword:
         return MaterialPageRoute(builder: (_) => const ForgotPasswordPage());
       case AppRoutes.resetPassword:

--- a/fix_connect_mobile/lib/core/constants/api_constants.dart
+++ b/fix_connect_mobile/lib/core/constants/api_constants.dart
@@ -27,7 +27,8 @@ class ApiConstants {
   // ── Auth ────────────────────────────────────────────────────────────────────
   static const login = '/auth/login';
   static const signup = '/auth/signup';
-  static const verifyOtp = '/auth/verify-otp';
+  static const verifyOtp = '/auth/otp/verify-email';
+  static const sendOtp = '/auth/otp/send';
   static const resendOtp = '/auth/resend-otp';
   static const forgotPassword = '/auth/forgot-password';
   static const resetPassword = '/auth/reset-password';

--- a/fix_connect_mobile/lib/core/di/injection_container.dart
+++ b/fix_connect_mobile/lib/core/di/injection_container.dart
@@ -7,6 +7,7 @@ import 'package:fix_connect_mobile/features/onboarding/auth/domain/repositories/
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/forgot_password_usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/login_usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/reset_password_usecase.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/send_otp_usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/signup_usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/verify_otp_usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/presentation/blocs/forgot_password_bloc.dart';
@@ -59,6 +60,9 @@ Future<void> initDependencies() async {
   sl.registerLazySingleton<SignupUseCase>(
     () => SignupUseCase(sl<AuthRepository>()),
   );
+  sl.registerLazySingleton<SendOtpUseCase>(
+    () => SendOtpUseCase(sl<AuthRepository>()),
+  );
   sl.registerLazySingleton<VerifyOtpUseCase>(
     () => VerifyOtpUseCase(sl<AuthRepository>()),
   );
@@ -74,7 +78,10 @@ Future<void> initDependencies() async {
     () => LoginBloc(loginUseCase: sl<LoginUseCase>()),
   );
   sl.registerFactory<SignupBloc>(
-    () => SignupBloc(signupUseCase: sl<SignupUseCase>()),
+    () => SignupBloc(
+      signupUseCase: sl<SignupUseCase>(),
+      sendOtpUseCase: sl<SendOtpUseCase>(),
+    ),
   );
   sl.registerFactory<OtpBloc>(
     () => OtpBloc(verifyOtpUseCase: sl<VerifyOtpUseCase>()),

--- a/fix_connect_mobile/lib/core/network/api_client.dart
+++ b/fix_connect_mobile/lib/core/network/api_client.dart
@@ -77,10 +77,13 @@ class ApiClient {
       case DioExceptionType.badResponse:
         final code = e.response?.statusCode;
         if (code == 401) return const UnauthorizedException();
-        final message =
-            (e.response?.data as Map<String, dynamic>?)?['message']
-                as String? ??
-            'Server error';
+        final body = e.response?.data as Map<String, dynamic>?;
+        final raw = body?['message'];
+        final message = switch (raw) {
+          final List list => list.join(', '),
+          final String s => s,
+          _ => body?['error'] as String? ?? 'Server error',
+        };
         return ServerException(message: message, statusCode: code);
       default:
         return ServerException(message: e.message ?? 'Unknown error');

--- a/fix_connect_mobile/lib/core/utils/assets_helper.dart
+++ b/fix_connect_mobile/lib/core/utils/assets_helper.dart
@@ -24,10 +24,12 @@ class ImageAssets {
     height: size,
     fit: BoxFit.contain,
   );
-  static Widget apple({double size = 24}) => SvgPicture.asset(
-    '${iconEndPoint}apple.svg',
-    width: size,
-    height: size,
-    fit: BoxFit.contain,
-  );
+  static Widget apple({double size = 24, Color color = Colors.black}) =>
+      SvgPicture.asset(
+        '${iconEndPoint}apple.svg',
+        width: size,
+        height: size,
+        fit: BoxFit.contain,
+        colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+      );
 }

--- a/fix_connect_mobile/lib/core/widgets/input_primary.dart
+++ b/fix_connect_mobile/lib/core/widgets/input_primary.dart
@@ -15,6 +15,7 @@ class InputPrimary extends StatefulWidget {
     this.suffixIcon,
     this.obscureText,
     this.autofocus,
+    this.keyboardType,
   });
 
   final String? label;
@@ -25,6 +26,7 @@ class InputPrimary extends StatefulWidget {
   final bool? obscureText;
   final bool? autofocus;
   final TextEditingController controller;
+  final TextInputType? keyboardType;
 
   @override
   State<InputPrimary> createState() => _InputPrimaryState();
@@ -91,6 +93,7 @@ class _InputPrimaryState extends State<InputPrimary> {
                     controller: widget.controller,
                     autofocus: widget.autofocus ?? false,
                     focusNode: widget.focusNode,
+                    keyboardType: widget.keyboardType,
                     maxLines: 1,
                     style: Theme.of(
                       context,

--- a/fix_connect_mobile/lib/features/onboarding/auth/data/datasources/auth_remote_datasource.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/data/datasources/auth_remote_datasource.dart
@@ -8,19 +8,19 @@ abstract interface class AuthRemoteDataSource {
   Future<UserDto> login({required String email, required String password});
 
   Future<void> signup({
-    required String name,
+    required String firstName,
+    required String lastName,
     required String email,
     required String phone,
     required String password,
+    String role = 'CUSTOMER',
   });
 
-  Future<UserDto> verifyOtp({
-    required String email,
-    required String otp,
-    required String purpose,
-  });
+  Future<UserDto?> verifyOtp({required String email, required String code});
 
   Future<void> resendOtp({required String email, required String purpose});
+
+  Future<void> sendOtp({required String email, required String purpose});
 
   Future<void> forgotPassword({required String email});
 
@@ -58,38 +58,52 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
 
   @override
   Future<void> signup({
-    required String name,
+    required String firstName,
+    required String lastName,
     required String email,
     required String phone,
     required String password,
-  }) async {
-    await _api.post<void>(
-      ApiConstants.signup,
-      data: {
-        'name': name,
-        'email': email,
-        'phone': phone,
-        'password': password,
-      },
-    );
-  }
-
-  @override
-  Future<UserDto> verifyOtp({
-    required String email,
-    required String otp,
-    required String purpose,
+    String role = 'CUSTOMER',
   }) async {
     final response = await _api.post<Map<String, dynamic>>(
-      ApiConstants.verifyOtp,
-      data: {'email': email, 'otp': otp, 'purpose': purpose},
+      ApiConstants.signup,
+      data: {
+        'firstName': firstName,
+        'lastName': lastName,
+        'email': email,
+        if (phone.isNotEmpty) 'phone': phone,
+        'password': password,
+        'role': role.toUpperCase(),
+      },
     );
     final data = response.data!;
+    // Persist tokens so the subsequent OTP-verify call can use them.
     await _tokenStorage.saveTokens(
       accessToken: data['accessToken'] as String,
       refreshToken: data['refreshToken'] as String,
     );
-    return UserDto.fromJson(data['user'] as Map<String, dynamic>);
+  }
+
+  @override
+  Future<UserDto?> verifyOtp({
+    required String email,
+    required String code,
+  }) async {
+    final response = await _api.post<Map<String, dynamic>>(
+      ApiConstants.verifyOtp,
+      data: {'email': email, 'code': code},
+    );
+    final data = response.data ?? {};
+    final accessToken = data['accessToken'] as String?;
+    final refreshToken = data['refreshToken'] as String?;
+    if (accessToken != null) {
+      await _tokenStorage.saveTokens(
+        accessToken: accessToken,
+        refreshToken: refreshToken ?? '',
+      );
+    }
+    final userData = data['user'] as Map<String, dynamic>?;
+    return userData != null ? UserDto.fromJson(userData) : null;
   }
 
   @override
@@ -99,6 +113,14 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   }) async {
     await _api.post<void>(
       ApiConstants.resendOtp,
+      data: {'email': email, 'purpose': purpose},
+    );
+  }
+
+  @override
+  Future<void> sendOtp({required String email, required String purpose}) async {
+    await _api.post<void>(
+      ApiConstants.sendOtp,
       data: {'email': email, 'purpose': purpose},
     );
   }

--- a/fix_connect_mobile/lib/features/onboarding/auth/data/repositories/auth_repository_impl.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/data/repositories/auth_repository_impl.dart
@@ -40,27 +40,31 @@ class AuthRepositoryImpl implements AuthRepository {
 
   @override
   Future<Result<void>> signup({
-    required String name,
+    required String firstName,
+    required String lastName,
     required String email,
     required String phone,
     required String password,
+    String role = 'CUSTOMER',
   }) => _safeCall(
     () => _remoteDataSource.signup(
-      name: name,
+      firstName: firstName,
+      lastName: lastName,
       email: email,
       phone: phone,
       password: password,
+      role: role,
     ),
   );
 
   @override
-  Future<Result<UserEntity>> verifyOtp({
+  Future<Result<UserEntity?>> verifyOtp({
     required String email,
-    required String otp,
-    required String purpose,
-  }) => _safeCall(
-    () => _remoteDataSource.verifyOtp(email: email, otp: otp, purpose: purpose),
-  );
+    required String code,
+  }) => _safeCall<UserEntity?>(() async {
+    final dto = await _remoteDataSource.verifyOtp(email: email, code: code);
+    return dto;
+  });
 
   @override
   Future<Result<void>> resendOtp({
@@ -68,6 +72,14 @@ class AuthRepositoryImpl implements AuthRepository {
     required String purpose,
   }) => _safeCall(
     () => _remoteDataSource.resendOtp(email: email, purpose: purpose),
+  );
+
+  @override
+  Future<Result<void>> sendOtp({
+    required String email,
+    required String purpose,
+  }) => _safeCall(
+    () => _remoteDataSource.sendOtp(email: email, purpose: purpose),
   );
 
   @override

--- a/fix_connect_mobile/lib/features/onboarding/auth/domain/repositories/auth_repository.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/domain/repositories/auth_repository.dart
@@ -9,20 +9,26 @@ abstract interface class AuthRepository {
   });
 
   Future<Result<void>> signup({
-    required String name,
+    required String firstName,
+    required String lastName,
     required String email,
     required String phone,
     required String password,
+    String role = 'CUSTOMER',
   });
 
-  /// [purpose] is either "signup" or "forgot_password".
-  Future<Result<UserEntity>> verifyOtp({
+  /// Returns the verified [UserEntity] if the server includes it, otherwise null.
+  Future<Result<UserEntity?>> verifyOtp({
     required String email,
-    required String otp,
-    required String purpose,
+    required String code,
   });
 
   Future<Result<void>> resendOtp({
+    required String email,
+    required String purpose,
+  });
+
+  Future<Result<void>> sendOtp({
     required String email,
     required String purpose,
   });

--- a/fix_connect_mobile/lib/features/onboarding/auth/domain/usecases/send_otp_usecase.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/domain/usecases/send_otp_usecase.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+import 'package:fix_connect_mobile/core/errors/result.dart';
+import 'package:fix_connect_mobile/core/usecases/usecase.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/domain/repositories/auth_repository.dart';
+
+class SendOtpUseCase implements UseCase<void, SendOtpParams> {
+  const SendOtpUseCase(this._repository);
+
+  final AuthRepository _repository;
+
+  @override
+  Future<Result<void>> call(SendOtpParams params) =>
+      _repository.sendOtp(email: params.email, purpose: params.purpose);
+}
+
+class SendOtpParams extends Equatable {
+  const SendOtpParams({required this.email, required this.purpose});
+
+  final String email;
+
+  /// e.g. "VERIFY_EMAIL"
+  final String purpose;
+
+  @override
+  List<Object?> get props => [email, purpose];
+}

--- a/fix_connect_mobile/lib/features/onboarding/auth/domain/usecases/signup_usecase.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/domain/usecases/signup_usecase.dart
@@ -10,26 +10,32 @@ class SignupUseCase implements UseCase<void, SignupParams> {
 
   @override
   Future<Result<void>> call(SignupParams params) => _repository.signup(
-    name: params.name,
+    firstName: params.firstName,
+    lastName: params.lastName,
     email: params.email,
     phone: params.phone,
     password: params.password,
+    role: params.role,
   );
 }
 
 class SignupParams extends Equatable {
   const SignupParams({
-    required this.name,
+    required this.firstName,
+    required this.lastName,
     required this.email,
-    required this.phone,
     required this.password,
+    this.phone = '',
+    this.role = 'CUSTOMER',
   });
 
-  final String name;
+  final String firstName;
+  final String lastName;
   final String email;
   final String phone;
   final String password;
+  final String role;
 
   @override
-  List<Object?> get props => [name, email, phone];
+  List<Object?> get props => [firstName, lastName, email, phone, role];
 }

--- a/fix_connect_mobile/lib/features/onboarding/auth/domain/usecases/verify_otp_usecase.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/domain/usecases/verify_otp_usecase.dart
@@ -4,29 +4,22 @@ import 'package:fix_connect_mobile/core/usecases/usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/entities/user_entity.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/repositories/auth_repository.dart';
 
-class VerifyOtpUseCase implements UseCase<UserEntity, VerifyOtpParams> {
+class VerifyOtpUseCase implements UseCase<UserEntity?, VerifyOtpParams> {
   const VerifyOtpUseCase(this._repository);
 
   final AuthRepository _repository;
 
   @override
-  Future<Result<UserEntity>> call(VerifyOtpParams params) => _repository
-      .verifyOtp(email: params.email, otp: params.otp, purpose: params.purpose);
+  Future<Result<UserEntity?>> call(VerifyOtpParams params) =>
+      _repository.verifyOtp(email: params.email, code: params.code);
 }
 
 class VerifyOtpParams extends Equatable {
-  const VerifyOtpParams({
-    required this.email,
-    required this.otp,
-    required this.purpose,
-  });
+  const VerifyOtpParams({required this.email, required this.code});
 
   final String email;
-  final String otp;
-
-  /// Either "signup" or "forgot_password".
-  final String purpose;
+  final String code;
 
   @override
-  List<Object?> get props => [email, otp, purpose];
+  List<Object?> get props => [email, code];
 }

--- a/fix_connect_mobile/lib/features/onboarding/auth/presentation/blocs/otp_bloc.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/presentation/blocs/otp_bloc.dart
@@ -14,20 +14,13 @@ sealed class OtpEvent extends Equatable {
 }
 
 final class OtpSubmitted extends OtpEvent {
-  const OtpSubmitted({
-    required this.email,
-    required this.otp,
-    required this.purpose,
-  });
+  const OtpSubmitted({required this.email, required this.code});
 
   final String email;
-  final String otp;
-
-  /// Either "signup" or "forgot_password".
-  final String purpose;
+  final String code;
 
   @override
-  List<Object?> get props => [email, otp, purpose];
+  List<Object?> get props => [email, code];
 }
 
 final class OtpResendRequested extends OtpEvent {
@@ -101,11 +94,7 @@ class OtpBloc extends Bloc<OtpEvent, OtpState> {
   Future<void> _onSubmitted(OtpSubmitted event, Emitter<OtpState> emit) async {
     emit(const OtpLoading());
     final result = await _verifyOtpUseCase(
-      VerifyOtpParams(
-        email: event.email,
-        otp: event.otp,
-        purpose: event.purpose,
-      ),
+      VerifyOtpParams(email: event.email, code: event.code),
     );
     switch (result) {
       case Ok(:final value):

--- a/fix_connect_mobile/lib/features/onboarding/auth/presentation/blocs/signup_bloc.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/presentation/blocs/signup_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:fix_connect_mobile/core/errors/result.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/send_otp_usecase.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/domain/usecases/signup_usecase.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -14,19 +15,23 @@ sealed class SignupEvent extends Equatable {
 
 final class SignupSubmitted extends SignupEvent {
   const SignupSubmitted({
-    required this.name,
+    required this.firstName,
+    required this.lastName,
     required this.email,
-    required this.phone,
     required this.password,
+    this.phone = '',
+    this.role = 'CUSTOMER',
   });
 
-  final String name;
+  final String firstName;
+  final String lastName;
   final String email;
   final String phone;
   final String password;
+  final String role;
 
   @override
-  List<Object?> get props => [name, email, phone];
+  List<Object?> get props => [firstName, lastName, email, phone, role];
 }
 
 // ── States ────────────────────────────────────────────────────────────────────
@@ -72,13 +77,17 @@ final class SignupFailure extends SignupState {
 /// On [SignupSuccess] the widget should navigate to the OTP page,
 /// passing `OtpArgs(email: state.email, source: OtpSource.signup)`.
 class SignupBloc extends Bloc<SignupEvent, SignupState> {
-  SignupBloc({required SignupUseCase signupUseCase})
-    : _signupUseCase = signupUseCase,
-      super(const SignupInitial()) {
+  SignupBloc({
+    required SignupUseCase signupUseCase,
+    required SendOtpUseCase sendOtpUseCase,
+  }) : _signupUseCase = signupUseCase,
+       _sendOtpUseCase = sendOtpUseCase,
+       super(const SignupInitial()) {
     on<SignupSubmitted>(_onSubmitted);
   }
 
   final SignupUseCase _signupUseCase;
+  final SendOtpUseCase _sendOtpUseCase;
 
   Future<void> _onSubmitted(
     SignupSubmitted event,
@@ -87,15 +96,26 @@ class SignupBloc extends Bloc<SignupEvent, SignupState> {
     emit(const SignupLoading());
     final result = await _signupUseCase(
       SignupParams(
-        name: event.name,
+        firstName: event.firstName,
+        lastName: event.lastName,
         email: event.email,
         phone: event.phone,
         password: event.password,
+        role: event.role,
       ),
     );
     switch (result) {
       case Ok():
-        emit(SignupSuccess(event.email));
+        // Trigger OTP send before navigating to the OTP page.
+        final otpResult = await _sendOtpUseCase(
+          SendOtpParams(email: event.email, purpose: 'VERIFY_EMAIL'),
+        );
+        switch (otpResult) {
+          case Ok():
+            emit(SignupSuccess(event.email));
+          case Err(:final failure):
+            emit(SignupFailure(failure.message));
+        }
       case Err(:final failure):
         emit(SignupFailure(failure.message));
     }

--- a/fix_connect_mobile/lib/features/onboarding/auth/presentation/pages/login_page.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/presentation/pages/login_page.dart
@@ -72,7 +72,10 @@ class _LoginPageState extends State<LoginPage> {
             ..hideCurrentSnackBar()
             ..showSnackBar(
               SnackBar(
-                content: Text(state.message),
+                content: Text(
+                  state.message,
+                  style: const TextStyle(color: Colors.white),
+                ),
                 backgroundColor: Theme.of(context).colorScheme.error,
               ),
             );
@@ -206,7 +209,7 @@ class _LoginPageState extends State<LoginPage> {
                             ),
                             SizedBox(width: AppSpacing.custom16),
                             SocialIconButton(
-                              asset: ImageAssets.apple(),
+                              asset: ImageAssets.apple(color: Colors.white),
                               onTap: () {},
                             ),
                           ],

--- a/fix_connect_mobile/lib/features/onboarding/auth/presentation/pages/otp_page.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/presentation/pages/otp_page.dart
@@ -7,6 +7,7 @@ import 'package:fix_connect_mobile/app/theme/app_spacing.dart';
 import 'package:fix_connect_mobile/app/theme/app_text_styles.dart';
 import 'package:fix_connect_mobile/core/utils/build_context_ext.dart';
 import 'package:fix_connect_mobile/core/widgets/button_primary.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/presentation/blocs/otp_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_otp_text_field/flutter_otp_text_field.dart';
@@ -25,10 +26,16 @@ class _OtpPageState extends State<OtpPage> {
   String _enteredCode = '';
 
   void _onSubmit() {
+    context.read<OtpBloc>().add(
+      OtpSubmitted(email: widget.args.email, code: _enteredCode),
+    );
+  }
+
+  void _onSuccess(BuildContext context, OtpSuccess state) {
     if (widget.args.source == OtpSource.forgotPassword) {
       Navigator.of(context).pushReplacementNamed(AppRoutes.resetPassword);
     } else {
-      context.read<AuthCubit>().logIn();
+      context.read<AuthCubit>().logIn(state.user);
     }
   }
 
@@ -40,93 +47,122 @@ class _OtpPageState extends State<OtpPage> {
     final bgColor = context.bgColor;
     final surfaceColor = context.surfaceColor;
 
-    return Scaffold(
-      backgroundColor: bgColor,
-      appBar: AppBar(
+    return BlocListener<OtpBloc, OtpState>(
+      listener: (context, state) {
+        if (state is OtpSuccess) {
+          _onSuccess(context, state);
+        } else if (state is OtpFailure) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                content: Text(
+                  state.message,
+                  style: const TextStyle(color: Colors.white),
+                ),
+                backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+            );
+        } else if (state is OtpResendSuccess) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                content: const Text(
+                  'Code resent!',
+                  style: TextStyle(color: Colors.white),
+                ),
+                backgroundColor: Theme.of(context).colorScheme.primary,
+              ),
+            );
+        }
+      },
+      child: Scaffold(
         backgroundColor: bgColor,
-        elevation: 0,
-        surfaceTintColor: Colors.transparent,
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.all(AppSpacing.custom16),
-          child: Center(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                AppGaps.h16,
-                Text(
-                  'Verify Code',
-                  style: AppTextStyles.header4Bold(
-                    color: textColor,
-                  ).copyWith(fontSize: 26),
-                  textAlign: TextAlign.center,
-                ),
-                AppGaps.h8,
-                Text(
-                  'We emailed you the four digit code to',
-                  style: AppTextStyles.bodyMediumRegular(
-                    color: textColor.withValues(alpha: 0.6),
+        appBar: AppBar(
+          backgroundColor: bgColor,
+          elevation: 0,
+          surfaceTintColor: Colors.transparent,
+        ),
+        body: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.all(AppSpacing.custom16),
+            child: Center(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  AppGaps.h16,
+                  Text(
+                    'Verify Code',
+                    style: Theme.of(context).textTheme.displayLarge,
                   ),
-                ),
-                Text(
-                  widget.args.email,
-                  style: AppTextStyles.bodyMediumMedium(color: primary),
-                ),
-                AppGaps.h32,
-                OtpTextField(
-                  numberOfFields: _otpCodeLength,
-                  showFieldAsBox: true,
-                  filled: true,
-                  fillColor: surfaceColor,
-                  borderColor: isDark ? AppColors.grey700 : AppColors.grey300,
-                  focusedBorderColor: primary,
-                  enabledBorderColor: isDark
-                      ? AppColors.grey700
-                      : AppColors.grey300,
-                  borderWidth: 1.5,
-                  fieldWidth: 64,
-                  fieldHeight: 64,
-                  borderRadius: BorderRadius.circular(14),
-                  cursorColor: primary,
-                  textStyle: AppTextStyles.header4Bold(
-                    color: textColor,
-                  ).copyWith(fontSize: 24),
-                  keyboardType: TextInputType.number,
-                  onCodeChanged: (code) => setState(() => _enteredCode = code),
-                  onSubmit: (String verificationCode) {
-                    setState(() => _enteredCode = verificationCode);
-                  },
-                ),
-                AppGaps.h24,
-                Text(
-                  "Didn't receive the code?",
-                  style: AppTextStyles.bodyMediumRegular(
-                    color: textColor.withValues(alpha: 0.6),
+                  AppGaps.h8,
+                  Text(
+                    'We emailed you the four digit code to',
+                    style: Theme.of(context).textTheme.bodyMedium,
                   ),
-                ),
-                AppGaps.h4,
-                GestureDetector(
-                  onTap: () {
-                    // TODO: trigger resend OTP API call
-                  },
-                  child: Text(
-                    'Resend Code',
-                    style: AppTextStyles.bodyMediumMedium(color: primary)
-                        .copyWith(
-                          decoration: TextDecoration.underline,
-                          decorationColor: primary,
-                        ),
+                  Text(
+                    widget.args.email,
+                    style: AppTextStyles.bodyMediumMedium(color: primary),
                   ),
-                ),
-                AppGaps.h32,
-                ButtonPrimary(
-                  text: 'Submit',
-                  bgColor: primary,
-                  enabled: _enteredCode.length == _otpCodeLength,
-                  onTap: _onSubmit,
-                ),
-              ],
+                  AppGaps.h32,
+                  OtpTextField(
+                    numberOfFields: _otpCodeLength,
+                    showFieldAsBox: true,
+                    filled: true,
+                    fillColor: surfaceColor,
+                    borderColor: isDark ? AppColors.grey700 : AppColors.grey300,
+                    focusedBorderColor: primary,
+                    enabledBorderColor: isDark
+                        ? AppColors.grey700
+                        : AppColors.grey300,
+                    borderWidth: 1.5,
+                    fieldWidth: 64,
+                    fieldHeight: 64,
+                    borderRadius: BorderRadius.circular(14),
+                    cursorColor: primary,
+                    textStyle: AppTextStyles.header4Bold(
+                      color: textColor,
+                    ).copyWith(fontSize: 24),
+                    keyboardType: TextInputType.number,
+                    onCodeChanged: (code) =>
+                        setState(() => _enteredCode = code),
+                    onSubmit: (String verificationCode) {
+                      setState(() => _enteredCode = verificationCode);
+                    },
+                  ),
+                  AppGaps.h24,
+                  Text(
+                    "Didn't receive the code?",
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  AppGaps.h4,
+                  GestureDetector(
+                    onTap: () {
+                      // TODO: trigger resend OTP API call
+                    },
+                    child: Text(
+                      'Resend Code',
+                      style: Theme.of(context).textTheme.bodyMedium
+                          ?.copyWith(color: primary)
+                          .copyWith(decoration: TextDecoration.underline),
+                    ),
+                  ),
+
+                  AppGaps.h32,
+                  BlocBuilder<OtpBloc, OtpState>(
+                    builder: (context, state) => ButtonPrimary(
+                      text: 'Submit',
+                      bgColor: primary,
+                      isLoading: state is OtpLoading,
+                      enabled:
+                          _enteredCode.length == _otpCodeLength &&
+                          state is! OtpLoading,
+                      onTap: _onSubmit,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/fix_connect_mobile/lib/features/onboarding/auth/presentation/pages/signup_page.dart
+++ b/fix_connect_mobile/lib/features/onboarding/auth/presentation/pages/signup_page.dart
@@ -6,7 +6,9 @@ import 'package:fix_connect_mobile/core/widgets/button_primary.dart';
 import 'package:fix_connect_mobile/core/widgets/input_primary.dart';
 import 'package:fix_connect_mobile/core/widgets/social_icon_button.dart';
 import 'package:fix_connect_mobile/features/onboarding/auth/data/models/otp_args.dart';
+import 'package:fix_connect_mobile/features/onboarding/auth/presentation/blocs/signup_bloc.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SignupPage extends StatefulWidget {
   const SignupPage({super.key});
@@ -22,19 +24,24 @@ class _SignupPageState extends State<SignupPage> {
       TextEditingController();
   final TextEditingController _textEditingControllerEmail =
       TextEditingController();
+  final TextEditingController _textEditingControllerPhone =
+      TextEditingController();
   final TextEditingController _textEditingControllerPassword =
       TextEditingController();
   final FocusNode _focusNodeFirstname = FocusNode();
   final FocusNode _focusNodeLastname = FocusNode();
   final FocusNode _focusNodeEmail = FocusNode();
+  final FocusNode _focusNodePhone = FocusNode();
   final FocusNode _focusNodePassword = FocusNode();
 
   bool _passwordObscured = true;
+  String _selectedRole = 'CUSTOMER';
 
   bool get _canSignUp =>
       _textEditingControllerFirstname.text.trim().isNotEmpty &&
       _textEditingControllerLastname.text.trim().isNotEmpty &&
       _textEditingControllerEmail.text.trim().isNotEmpty &&
+      _textEditingControllerPhone.text.trim().isNotEmpty &&
       _textEditingControllerPassword.text.isNotEmpty;
 
   @override
@@ -43,6 +50,7 @@ class _SignupPageState extends State<SignupPage> {
     _textEditingControllerFirstname.addListener(() => setState(() {}));
     _textEditingControllerLastname.addListener(() => setState(() {}));
     _textEditingControllerEmail.addListener(() => setState(() {}));
+    _textEditingControllerPhone.addListener(() => setState(() {}));
     _textEditingControllerPassword.addListener(() => setState(() {}));
   }
 
@@ -55,10 +63,12 @@ class _SignupPageState extends State<SignupPage> {
   @override
   void dispose() {
     _textEditingControllerPassword.dispose();
+    _textEditingControllerPhone.dispose();
     _textEditingControllerEmail.dispose();
     _textEditingControllerLastname.dispose();
     _textEditingControllerFirstname.dispose();
     _focusNodeEmail.dispose();
+    _focusNodePhone.dispose();
     _focusNodeLastname.dispose();
     _focusNodeFirstname.dispose();
     _focusNodePassword.dispose();
@@ -69,214 +79,377 @@ class _SignupPageState extends State<SignupPage> {
     Navigator.of(context).pushReplacementNamed(AppRoutes.login);
   }
 
-  void _goToOtp() {
-    Navigator.of(context).pushNamed(
-      AppRoutes.otp,
-      arguments: OtpArgs(
-        email: _textEditingControllerEmail.text.trim(),
-        source: OtpSource.signup,
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.all(AppSpacing.custom16),
-          child: Column(
-            children: [
-              /// 🔹 Scrollable content
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Column(
-                    children: [
-                      Text(
-                        'Create Account',
-                        style: Theme.of(context).textTheme.displayLarge,
-                      ),
-                      AppGaps.h4,
-                      Text(
-                        'Create an account to find trusted experts near you and get your jobs done hassle-free.',
-                        style: Theme.of(context).textTheme.bodyMedium,
-                        textAlign: TextAlign.center,
-                      ),
-                      AppGaps.h32,
+    final primary = Theme.of(context).primaryColor;
+    final scheme = Theme.of(context).colorScheme;
 
-                      /// First name
-                      InputPrimary(
-                        focusNode: _focusNodeFirstname,
-                        controller: _textEditingControllerFirstname,
-                        autofocus: true,
-                        label: 'First name',
-                        prefixIcon: Icon(
-                          Icons.person,
-                          color: Theme.of(context).colorScheme.primary,
+    return BlocListener<SignupBloc, SignupState>(
+      listener: (context, state) {
+        if (state is SignupSuccess) {
+          Navigator.of(context).pushNamed(
+            AppRoutes.otp,
+            arguments: OtpArgs(email: state.email, source: OtpSource.signup),
+          );
+        } else if (state is SignupFailure) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                content: Text(
+                  state.message,
+                  style: const TextStyle(color: Colors.white),
+                ),
+                backgroundColor: scheme.error,
+              ),
+            );
+        }
+      },
+      child: Scaffold(
+        body: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: AppSpacing.custom16),
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.only(
+                      top: AppSpacing.custom24,
+                      bottom: AppSpacing.custom16,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        /// Header
+                        Text(
+                          'Create Account',
+                          style: Theme.of(context).textTheme.displayLarge,
                         ),
-                      ),
-
-                      AppGaps.h8,
-
-                      /// Last name
-                      InputPrimary(
-                        focusNode: _focusNodeLastname,
-                        controller: _textEditingControllerLastname,
-                        label: 'Last name',
-                        prefixIcon: Icon(
-                          Icons.person,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ),
-
-                      AppGaps.h8,
-
-                      /// Email
-                      InputPrimary(
-                        focusNode: _focusNodeEmail,
-                        controller: _textEditingControllerEmail,
-                        label: 'Email',
-                        prefixIcon: Icon(
-                          Icons.email,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ),
-
-                      AppGaps.h8,
-
-                      /// Password
-                      InputPrimary(
-                        obscureText: _passwordObscured,
-                        focusNode: _focusNodePassword,
-                        controller: _textEditingControllerPassword,
-                        label: 'Password',
-                        prefixIcon: Icon(
-                          Icons.lock,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                        suffixIcon: Padding(
-                          padding: EdgeInsets.only(right: AppSpacing.custom4),
-                          child: GestureDetector(
-                            onTap: _togglePasswordObscured,
-                            child: Icon(
-                              _passwordObscured
-                                  ? Icons.visibility_off_rounded
-                                  : Icons.visibility_rounded,
-                              size: AppSpacing.custom24,
-                            ),
-                          ),
-                        ),
-                      ),
-
-                      AppGaps.h8,
-
-                      /// Terms and conditions
-                      RichText(
-                        textAlign: TextAlign.center,
-                        text: TextSpan(
-                          text: 'By creating an account, you agree to our ',
+                        AppGaps.h4,
+                        Text(
+                          'Find trusted experts or offer your skills.',
                           style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+
+                        AppGaps.h24,
+
+                        /// Role cards
+                        Text(
+                          'I am a…',
+                          style: Theme.of(context).textTheme.labelLarge,
+                        ),
+                        AppGaps.h8,
+                        Row(
                           children: [
-                            TextSpan(
-                              text: 'Terms of Service',
-                              style: Theme.of(context).textTheme.bodyMedium
-                                  ?.copyWith(
-                                    color: Theme.of(context).primaryColor,
-                                  ),
+                            _RoleCard(
+                              icon: Icons.person_search_rounded,
+                              title: 'Customer',
+                              subtitle: 'I need a pro',
+                              selected: _selectedRole == 'CUSTOMER',
+                              onTap: () =>
+                                  setState(() => _selectedRole = 'CUSTOMER'),
+                              primary: primary,
+                              scheme: scheme,
                             ),
-                            TextSpan(
-                              text: ' and ',
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            TextSpan(
-                              text: 'Privacy Policy',
-                              style: Theme.of(context).textTheme.bodyMedium
-                                  ?.copyWith(
-                                    color: Theme.of(context).primaryColor,
-                                  ),
-                            ),
-                            TextSpan(
-                              text: '.',
-                              style: Theme.of(context).textTheme.bodyMedium,
+                            SizedBox(width: AppSpacing.custom16),
+                            _RoleCard(
+                              icon: Icons.construction_rounded,
+                              title: 'Artisan',
+                              subtitle: 'I fix things',
+                              selected: _selectedRole == 'ARTISAN',
+                              onTap: () =>
+                                  setState(() => _selectedRole = 'ARTISAN'),
+                              primary: primary,
+                              scheme: scheme,
                             ),
                           ],
                         ),
-                      ),
 
-                      AppGaps.h24,
+                        AppGaps.h16,
 
-                      /// Sign up button
-                      ButtonPrimary(
-                        onTap: _goToOtp,
-                        enabled: _canSignUp,
-                        text: 'Create Account',
-                        bgColor: Theme.of(context).primaryColor,
-                      ),
-
-                      AppGaps.h32,
-
-                      /// Divider
-                      Row(
-                        children: [
-                          const Expanded(child: Divider()),
-                          Padding(
-                            padding: EdgeInsets.symmetric(
-                              horizontal: AppSpacing.custom8,
+                        /// Name row
+                        Row(
+                          children: [
+                            Expanded(
+                              child: InputPrimary(
+                                focusNode: _focusNodeFirstname,
+                                controller: _textEditingControllerFirstname,
+                                autofocus: true,
+                                label: 'First name',
+                              ),
                             ),
-                            child: Text(
-                              'Or continue with',
-                              style: Theme.of(context).textTheme.bodyMedium,
+                            SizedBox(width: AppSpacing.custom16),
+                            Expanded(
+                              child: InputPrimary(
+                                focusNode: _focusNodeLastname,
+                                controller: _textEditingControllerLastname,
+                                label: 'Last name',
+                              ),
+                            ),
+                          ],
+                        ),
+
+                        AppGaps.h10,
+
+                        /// Email
+                        InputPrimary(
+                          focusNode: _focusNodeEmail,
+                          controller: _textEditingControllerEmail,
+                          label: 'Email',
+                          keyboardType: TextInputType.emailAddress,
+                          prefixIcon: Icon(
+                            Icons.mail_outline_rounded,
+                            color: scheme.primary,
+                          ),
+                        ),
+
+                        AppGaps.h10,
+
+                        /// Phone
+                        InputPrimary(
+                          focusNode: _focusNodePhone,
+                          controller: _textEditingControllerPhone,
+                          label: 'Phone number',
+                          keyboardType: TextInputType.phone,
+                          prefixIcon: Icon(
+                            Icons.phone_outlined,
+                            color: scheme.primary,
+                          ),
+                        ),
+
+                        AppGaps.h10,
+
+                        /// Password
+                        InputPrimary(
+                          obscureText: _passwordObscured,
+                          focusNode: _focusNodePassword,
+                          controller: _textEditingControllerPassword,
+                          label: 'Password',
+                          prefixIcon: Icon(
+                            Icons.lock_outline_rounded,
+                            color: scheme.primary,
+                          ),
+                          suffixIcon: Padding(
+                            padding: EdgeInsets.only(right: AppSpacing.custom4),
+                            child: GestureDetector(
+                              onTap: _togglePasswordObscured,
+                              child: Icon(
+                                _passwordObscured
+                                    ? Icons.visibility_off_outlined
+                                    : Icons.visibility_outlined,
+                                size: AppSpacing.custom24,
+                              ),
                             ),
                           ),
-                          const Expanded(child: Divider()),
-                        ],
+                        ),
+
+                        AppGaps.h24,
+
+                        /// Create Account button
+                        BlocBuilder<SignupBloc, SignupState>(
+                          builder: (context, state) => ButtonPrimary(
+                            enabled: _canSignUp && state is! SignupLoading,
+                            isLoading: state is SignupLoading,
+                            text: 'Create Account',
+                            bgColor: primary,
+                            onTap: () => context.read<SignupBloc>().add(
+                              SignupSubmitted(
+                                firstName: _textEditingControllerFirstname.text
+                                    .trim(),
+                                lastName: _textEditingControllerLastname.text
+                                    .trim(),
+                                email: _textEditingControllerEmail.text.trim(),
+                                phone: _textEditingControllerPhone.text.trim(),
+                                password: _textEditingControllerPassword.text,
+                                role: _selectedRole,
+                              ),
+                            ),
+                          ),
+                        ),
+
+                        AppGaps.h16,
+
+                        /// Terms
+                        Center(
+                          child: RichText(
+                            textAlign: TextAlign.center,
+                            text: TextSpan(
+                              text: 'By creating an account you agree to our ',
+                              style: Theme.of(context).textTheme.bodySmall,
+                              children: [
+                                TextSpan(
+                                  text: 'Terms',
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(color: primary),
+                                ),
+                                TextSpan(
+                                  text: ' & ',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                TextSpan(
+                                  text: 'Privacy Policy',
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(color: primary),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+
+                        AppGaps.h24,
+
+                        /// Divider
+                        Row(
+                          children: [
+                            const Expanded(child: Divider()),
+                            Padding(
+                              padding: EdgeInsets.symmetric(
+                                horizontal: AppSpacing.custom16,
+                              ),
+                              child: Text(
+                                'or',
+                                style: Theme.of(context).textTheme.bodySmall,
+                              ),
+                            ),
+                            const Expanded(child: Divider()),
+                          ],
+                        ),
+
+                        AppGaps.h16,
+
+                        /// Social buttons
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SocialIconButton(
+                              asset: ImageAssets.google(),
+                              onTap: () {},
+                            ),
+                            SizedBox(width: AppSpacing.custom16),
+                            SocialIconButton(
+                              asset: ImageAssets.facebook(),
+                              onTap: () {},
+                            ),
+                            SizedBox(width: AppSpacing.custom16),
+                            SocialIconButton(
+                              asset: ImageAssets.apple(color: Colors.white),
+                              onTap: () {},
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                /// Sign in link
+                Padding(
+                  padding: EdgeInsets.only(bottom: AppSpacing.custom8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'Already have an account?',
+                        style: Theme.of(context).textTheme.bodyMedium,
                       ),
-
-                      AppGaps.h32,
-
-                      /// Social buttons
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          SocialIconButton(
-                            asset: ImageAssets.google(),
-                            onTap: () {},
-                          ),
-                          SizedBox(width: AppSpacing.custom16),
-                          SocialIconButton(
-                            asset: ImageAssets.facebook(),
-                            onTap: () {},
-                          ),
-                          SizedBox(width: AppSpacing.custom16),
-                          SocialIconButton(
-                            asset: ImageAssets.apple(),
-                            onTap: () {},
-                          ),
-                        ],
+                      TextButton(
+                        onPressed: goBackToLogin,
+                        child: Text(
+                          'Sign In',
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodyMedium?.copyWith(color: primary),
+                        ),
                       ),
                     ],
                   ),
                 ),
-              ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
 
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    'Already have an account?',
-                    style: Theme.of(context).textTheme.bodyMedium,
-                  ),
-                  TextButton(
-                    onPressed: goBackToLogin,
-                    child: Text(
-                      'Sign In',
+// ── Role card ─────────────────────────────────────────────────────────────────
+
+class _RoleCard extends StatelessWidget {
+  const _RoleCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.selected,
+    required this.onTap,
+    required this.primary,
+    required this.scheme,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool selected;
+  final VoidCallback onTap;
+  final Color primary;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
+          decoration: BoxDecoration(
+            color: selected
+                ? primary.withValues(alpha: 0.08)
+                : Colors.transparent,
+            border: Border.all(
+              color: selected ? primary : scheme.outlineVariant,
+              width: selected ? 2 : 1,
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: selected ? primary : scheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(
+                  icon,
+                  size: 20,
+                  color: selected ? Colors.white : scheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).primaryColor,
+                        fontWeight: FontWeight.w600,
+                        color: selected ? primary : null,
                       ),
                     ),
-                  ),
-                ],
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
               ),
+              if (selected)
+                Icon(Icons.check_circle_rounded, size: 18, color: primary),
             ],
           ),
         ),


### PR DESCRIPTION
… cases

- Changed API endpoints for OTP verification and sending in `api_constants.dart`.
- Added `SendOtpUseCase` to handle sending OTP requests.
- Updated `AuthRemoteDataSource` and `AuthRepositoryImpl` to support new OTP functionality.
- Modified `SignupBloc` to trigger OTP sending upon successful signup.
- Enhanced `SignupPage` and `OtpPage` UI to reflect changes in the signup and OTP verification process.
- Improved error handling in API client for better user feedback.
- Added support for first and last names in the signup process.
- Updated input fields to include phone number and role selection.